### PR TITLE
Fix issue of getTransactionReceipt not displayed

### DIFF
--- a/rpc/ethRPC.go
+++ b/rpc/ethRPC.go
@@ -15,6 +15,7 @@ type Endpoint struct {
     ParsedURL *url.URL
     endpoint string
     isIPC bool
+    requestId int
 }
 
 // Represent the transaction 
@@ -46,6 +47,7 @@ func ConnectEndpoint(Rawurl string) (*Endpoint, error) {
         return &Endpoint{
             endpoint: Rawurl,
             isIPC: true,
+            requestId: 1,
         }, nil
     }
 
@@ -58,6 +60,7 @@ func ConnectEndpoint(Rawurl string) (*Endpoint, error) {
         ParsedURL: u, 
         endpoint: u.String(),
         isIPC: false,
+        requestId: 1,
     }, nil
 }
 

--- a/rpc/ethRPC.go
+++ b/rpc/ethRPC.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"net/url"
 	"os"
+	"time"
 )
 
 // Represent the parameters to allow multiple type
@@ -23,7 +24,18 @@ type Transaction struct {
     From  string `json:"from"`
     To    string `json:"to"`
     Value string `json:"value"`
-    Input string `json:"input"`
+    Input string `json:"data"`
+    // gasLimit int
+    // MaxPriorityFeePerGas int
+    // maxFeePerGas int
+    // nonce string
+}
+
+// Represent the transaction to create a contract
+type ContractCreationTr struct {
+    From  string `json:"from"`
+    Value string `json:"value"`
+    Input string `json:"data"`
     // gasLimit int
     // MaxPriorityFeePerGas int
     // maxFeePerGas int
@@ -36,6 +48,22 @@ type RPCTransaction struct {
     Method  string       `json:"method"`
     Params  []Parameters `json:"params"`
     Id      int          `json:"id"` //not sure what this is used for, seems like it can be anything.
+}
+
+type TransactionReceiptResponse struct {
+    BlockHash string `json:"blockHash"`
+    BlockNumber string `json:"blockNumber"`
+    ContractAddress string `json:"contractAddress"`
+    CumulativeGasUser string `json:"cumulativeGasUser"`
+    EffectiveGasPrice string `json:"effectiveGasPrice"`
+    From string `json:"from"`
+    GasUsed string `json:"gasUsed"`
+    LogsBloom string `json:"logsBloom"`
+    Status string `json:"status"`
+    To string `json:"to"`
+    TransactionHash string `json:"transactionHash"`
+    TransactionIndex string `json:"transactionIndex"`
+    Type string `json:"type"`
 }
 
 //Initialize the endpoint.
@@ -102,7 +130,7 @@ func BuildTransaction(from string, to string, value string, input string) Transa
     return transaction
 }
 
-func (ep *Endpoint) SendTransaction(transaction Transaction) (*RPCResponse, error) { //must be used with getTransactionReceipt to get the contract address after creating it.
+func (ep *Endpoint) SendTransaction(transaction interface{}) (*RPCResponse, error) { //must be used with getTransactionReceipt to get the contract address after creating it.
         return ep.Request([]Parameters{transaction}, RPCendpoint["SendTransaction"])
 }
 
@@ -165,16 +193,33 @@ func (ep *Endpoint) DeployContract(sender string, contractByteCodePath string) (
         return nil, err
     }
     contractPayload := fmt.Sprintf("0x%s", contractContent)
-    tr := BuildTransaction(sender, "0x0000000000000000000000000000000000000000", "0x0", contractPayload)
-    rep, err := ep.SendTransaction(tr)
+    //create a contract happen when no receiver are present in the field
+    // the 0x0 address does not work to create a contract
+    tr := ContractCreationTr{
+        From: sender,
+        Value: "0x0",
+        Input: contractPayload,
+    }
+    r, err := ep.SendTransaction(tr)
     if err != nil {
         return nil, err
     }
 
-    t, err := ep.GetTransactionReceipt(rep.Result)
+    //type assertion needed
+    result, ok := r.Result.(string); if !ok{
+        return nil, fmt.Errorf("Transaction hash is not a string: %v", r)
+    }
+    fmt.Println(result)
+
+    time.Sleep(50 * time.Millisecond) //otherwise it goes too fast
+
+    t, err := ep.GetTransactionReceipt(result)
     if err != nil {
         return nil, err
     }
+
+    fmt.Println(t.Result)
+
     return t, nil
 
 }

--- a/rpc/ethRPC_test.go
+++ b/rpc/ethRPC_test.go
@@ -207,10 +207,8 @@ func TestDeployContract(t *testing.T){
     if err != nil {
         t.Fatalf("error when deploying contract: %q", err)
     }
-    t.Logf("resp: %v", rep)
-    r, err := marshalling(rep)
     if err != nil {
         t.Errorf("Error Unmarshalling the answer: %q", err)
     }
-    t.Logf("Received answer: %s", r)
+    t.Logf("Received answer: %v", rep)
 }

--- a/rpc/ethRPC_test.go
+++ b/rpc/ethRPC_test.go
@@ -24,6 +24,7 @@ var (
 )
 
 //helper to help marshalling a answer into a string
+//NOTE could be move as an helper in RPC package ?
 func marshalling(answer *RPCResponse) (string, error){
     marshalled, err := json.Marshal(answer)
     if err != nil {

--- a/rpc/net.go
+++ b/rpc/net.go
@@ -18,7 +18,7 @@ type RPCError struct {
 type RPCResponse struct {
     Jsonrpc string `json:"jsonrpc"`
     Id int `json:"id"`
-    Result string `json:"result"`
+    Result any `json:"result"`
     Error *RPCError `json:"error"`
 }
 

--- a/rpc/net.go
+++ b/rpc/net.go
@@ -23,7 +23,7 @@ type RPCResponse struct {
 }
 
 func (ep *Endpoint) Request(Params []Parameters, rpcDetail RPCMethod) (*RPCResponse, error) {
-    RPCRequest := buildRPCRequest(Params, rpcDetail)
+    RPCRequest := ep.buildRPCRequest(Params, rpcDetail)
     json, err := json.Marshal(RPCRequest)
     if err != nil {
         return nil, err
@@ -97,12 +97,13 @@ func (ep *Endpoint) HttpRequest(httpMethod string, RPCjson []byte) (*RPCResponse
     return rpcResponse, nil
 }
 
-func buildRPCRequest(params []Parameters, method RPCMethod) (RPCTransaction){
+func (ep *Endpoint) buildRPCRequest(params []Parameters, method RPCMethod) (RPCTransaction){
     rpc := RPCTransaction{
         Jsonrpc:"2.0",
-        Id:66, //TODO maybe mettre un random in a given range
+        Id:ep.requestId, 
         Method:method.Method,
         Params:params,
     }
+    ep.requestId++
     return rpc
 }


### PR DESCRIPTION
The issue was coming from the type of the `result` field of the `RPCResponse` struct.
It was a string which was too restrictive as the result of `getTransactionReceipt` is a complex structure.

fixes #1 